### PR TITLE
Fix logic in response body DTO logging

### DIFF
--- a/WatchDog/src/WatchDog.cs
+++ b/WatchDog/src/WatchDog.cs
@@ -119,7 +119,9 @@ namespace WatchDog.src
                             ResponseBody = responseBody,
                             ResponseStatus = context.Response.StatusCode,
                             FinishTime = DateTime.Now,
-                            Headers = context.Response.StatusCode != 200 || context.Response.StatusCode != 201 ? "" : context.Response.Headers.Select(x => x.ToString()).Aggregate((a, b) => a + ": " + b),
+                            Headers = context.Response.StatusCode == 200 || context.Response.StatusCode == 201
+                                ? string.Empty
+                                : context.Response.Headers.Select(x => x.ToString()).Aggregate((a, b) => a + ": " + b),
                         };
                         await originalResponseBody.CopyToAsync(originalBodyStream);
                         return responseBodyDto;


### PR DESCRIPTION
- Fixes logic in response body DTO logging

Assuming include details if error; empty string if not. Either way, the logic is wrong because the Boolean expression always returns true the way it is written.

If status code is 200 then it is not 201 and if it is 201 then it is not 200 so the OR (||) expression does not work here. It should be an AND (&&) and it should be == instead of != since if you have a success code you don't want to include headers.