### PR TITLE
Sink standard ILogger logs to WatchDog

### DIFF
--- a/WatchDog/src/Extensions/WatchDogLogger.cs
+++ b/WatchDog/src/Extensions/WatchDogLogger.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+
+namespace WatchDog.Extensions
+{
+    public sealed class WatchDogLogger : ILogger
+    {
+        private readonly string _name;
+        private readonly Func<WatchDogLoggerConfiguration> _getCurrentConfig;
+
+        public WatchDogLogger(string name, Func<WatchDogLoggerConfiguration> getCurrentConfig) =>
+            (_name, _getCurrentConfig) = (name, getCurrentConfig);
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => default!;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter)
+        {
+            if (!IsEnabled(logLevel))
+                return;
+
+            WatchDogLoggerConfiguration config = _getCurrentConfig();
+            string message = $"{_name} - {formatter(state, exception)}";
+
+            StackFrame[] stackFrames = new StackTrace().GetFrames();
+            (string filePath, string callerName, int lineNumber) = GetCallerInfo(stackFrames);
+
+            switch (logLevel)
+            {
+                case LogLevel.None:
+                    return;
+
+                case LogLevel.Trace:
+                case LogLevel.Debug:
+                case LogLevel.Information:
+                    WatchLogger.Log(message, level: logLevel.ToString(), filePath: filePath, callerName: callerName, lineNumber: lineNumber);
+                    break;
+
+                case LogLevel.Warning:
+                    WatchLogger.LogWarning(message, filePath: filePath, callerName: callerName, lineNumber: lineNumber);
+                    break;
+
+                case LogLevel.Error:
+                case LogLevel.Critical:
+                    WatchLogger.LogError(message, filePath: filePath, callerName: callerName, lineNumber: lineNumber);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(logLevel), logLevel, null);
+            }
+        }
+
+        private static (string filePath, string callerName, int lineNumber) GetCallerInfo(IEnumerable<StackFrame> frames)
+        {
+            // Skip frames up to the actual logging call
+            foreach (var frame in frames)
+            {
+                MethodBase method = frame.GetMethod();
+                string assemblyName = method?.DeclaringType?.Assembly.GetName().Name;
+
+                switch (assemblyName)
+                {
+                    case "WatchDog":
+                    case "Microsoft.Extensions.Logging":
+                    case "Microsoft.Extensions.Logging.Abstractions":
+                    case "System.Runtime.CompilerServices":
+                        continue;
+                }
+
+                return (frame.GetFileName() ?? string.Empty,
+                        method?.Name ?? string.Empty,
+                        frame.GetFileLineNumber());
+            }
+
+            return (string.Empty, string.Empty, 0);
+        }
+    }
+}

--- a/WatchDog/src/Extensions/WatchDogLoggerConfiguration.cs
+++ b/WatchDog/src/Extensions/WatchDogLoggerConfiguration.cs
@@ -1,0 +1,6 @@
+﻿namespace WatchDog.Extensions
+{
+    public sealed class WatchDogLoggerConfiguration
+    {
+    }
+}

--- a/WatchDog/src/Extensions/WatchDogLoggerExtensions.cs
+++ b/WatchDog/src/Extensions/WatchDogLoggerExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+
+namespace WatchDog.Extensions
+{
+    public static class WatchDogLoggerExtensions
+    {
+        public static ILoggingBuilder AddWatchDogLogger(
+            this ILoggingBuilder builder)
+        {
+            builder.AddConfiguration();
+
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ILoggerProvider, WatchDogLoggerProvider>());
+
+            LoggerProviderOptions.RegisterProviderOptions
+                <WatchDogLoggerConfiguration, WatchDogLoggerProvider>(builder.Services);
+
+            return builder;
+        }
+
+        public static ILoggingBuilder AddWatchDogLogger(
+            this ILoggingBuilder builder,
+            Action<WatchDogLoggerConfiguration> configure)
+        {
+            builder.AddWatchDogLogger();
+            builder.Services.Configure(configure);
+
+            return builder;
+        }
+    }
+}

--- a/WatchDog/src/Extensions/WatchDogLoggerProvider.cs
+++ b/WatchDog/src/Extensions/WatchDogLoggerProvider.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace WatchDog.Extensions
+{
+    [ProviderAlias("WatchDog")]
+    public sealed class WatchDogLoggerProvider : ILoggerProvider
+    {
+        private readonly IDisposable? _onChangeToken;
+        private WatchDogLoggerConfiguration _currentConfig;
+        private readonly ConcurrentDictionary<string, WatchDogLogger> _loggers =
+            new ConcurrentDictionary<string, WatchDogLogger>(StringComparer.OrdinalIgnoreCase);
+
+        public WatchDogLoggerProvider(
+            IOptionsMonitor<WatchDogLoggerConfiguration> config)
+        {
+            _currentConfig = config.CurrentValue;
+            _onChangeToken = config.OnChange(updatedConfig => _currentConfig = updatedConfig);
+        }
+
+        public ILogger CreateLogger(string categoryName) =>
+            _loggers.GetOrAdd(categoryName, name => new WatchDogLogger(name, GetCurrentConfig));
+
+        private WatchDogLoggerConfiguration GetCurrentConfig() => _currentConfig;
+
+        public void Dispose()
+        {
+            _loggers.Clear();
+            _onChangeToken?.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Hello!

I was really interested in your project when I found it, but was disappointed to learn that it doesn't work out of the box for an application that is already filled with ILogger calls.

This adds the feature for registering a WatchDogLoggerProvider with the standard Microsoft logging builder:

```
builder.Services.AddLogging(b =>
{
    b.AddWatchDogLogger();
});
```

I added a whole bunch of jank to the WatchDogLogger to try and determine the caller info for an ILogger consumer. Honestly I don't really care for that information, but figured I'd try and provide something.