### PR TITLE
Replace the defective System.Data.SqlClient Nuget package 

### DIFF
--- a/WatchDog/WatchDog.csproj
+++ b/WatchDog/WatchDog.csproj
@@ -53,6 +53,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.1" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="3.1.22" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.22" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.22" />
@@ -65,7 +66,6 @@
 		<PackageReference Include="Npgsql" Version="[5.0.0,5.0.10]" Condition="'$(TargetFramework)' == 'netcoreapp3.1'" />
 		<PackageReference Include="Npgsql" Version="6.0.4" Condition="'$(TargetFramework)' == 'net6.0'" />
 		<PackageReference Include="Npgsql" Version="8.0.2" Condition="'$(TargetFramework)' == 'net8.0'" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
 	</ItemGroup>
 
 </Project>

--- a/WatchDog/src/Data/ExternalDbContext.cs
+++ b/WatchDog/src/Data/ExternalDbContext.cs
@@ -1,11 +1,11 @@
 ﻿using Dapper;
+using Microsoft.Data.SqlClient;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MySql.Data.MySqlClient;
 using Npgsql;
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Diagnostics;
 using WatchDog.src.Enums;
 using WatchDog.src.Exceptions;
@@ -38,7 +38,7 @@ namespace WatchDog.src.Data
                 try
                 {
                     connection.Open();
-                    _ =  connection.Query(createWatchTablesQuery);
+                    _ = connection.Query(createWatchTablesQuery);
                     connection.Close();
                 }
                 catch (SqlException ae)
@@ -83,7 +83,7 @@ namespace WatchDog.src.Data
                     _counter.InsertOne(sequence);
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Debug.WriteLine(ex.Message.ToString());
                 throw new WatchDogDatabaseException(ex.Message);


### PR DESCRIPTION
Replace the defective System.Data.SqlClient Nuget package To resolve an error Could not load type 'SqlGuidCaster' from assembly 'System.Data.SqlClient